### PR TITLE
Friendly heads up: switch to `github-readme-stats.shion.dev` 🌱

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 <h3 align="left"> Github Profile Trophies:</h3>  
 <p align="center"> 
   
-|  [![trophy](https://github-profile-trophy.vercel.app/?username=dionnenoellabarretto&theme=discord&no-bg=true)](https://github.com/DionneNoellaBarretto/github-profile-trophy)</p> [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=dionnenoellabarretto&layout=compact&theme=nightowl)](https://github.com/DionneNoellaBarretto/github-readme-stats) | <a href="https://app.daily.dev/dnb"><img src="https://api.daily.dev/devcards/2b2ffde3884c4d9d8b089e028c6d6e2b.png?r=o12" width="400" alt="Dionne Noella Barretto's Dev Card"/></a> <br/> [![DailyDev Status](https://github.com/DionneNoellaBarretto/dionnenoellabarretto/actions/workflows/DevCard.yml/badge.svg?branch=main)](https://github.com/DionneNoellaBarretto/dionnenoellabarretto/actions/workflows/DevCard.yml) 
+|  [![trophy](https://github-profile-trophy.vercel.app/?username=dionnenoellabarretto&theme=discord&no-bg=true)](https://github.com/DionneNoellaBarretto/github-profile-trophy)</p> [![Top Langs](https://github-readme-stats.shion.dev/api/top-langs/?username=dionnenoellabarretto&layout=compact&theme=nightowl)](https://github.com/DionneNoellaBarretto/github-readme-stats) | <a href="https://app.daily.dev/dnb"><img src="https://api.daily.dev/devcards/2b2ffde3884c4d9d8b089e028c6d6e2b.png?r=o12" width="400" alt="Dionne Noella Barretto's Dev Card"/></a> <br/> [![DailyDev Status](https://github.com/DionneNoellaBarretto/dionnenoellabarretto/actions/workflows/DevCard.yml/badge.svg?branch=main)](https://github.com/DionneNoellaBarretto/dionnenoellabarretto/actions/workflows/DevCard.yml) 
 |---| ---|
 
 <hr>
@@ -42,7 +42,7 @@
 <h3 align="center"> 
   🐱 GitHub Stats: </h3> 
   
- |  ![Dionne Noella's GitHub stats](https://github-readme-stats.vercel.app/api?username=dionnenoellabarretto&show_icons=true&theme=nightowl)    |    [![GitHub Streak](https://github-readme-streak-stats.herokuapp.com/?user=dionnenoellabarretto&theme=nightowl)](https://git.io/streak-stats)     |
+ |  ![Dionne Noella's GitHub stats](https://github-readme-stats.shion.dev/api?username=dionnenoellabarretto&show_icons=true&theme=nightowl)    |    [![GitHub Streak](https://github-readme-streak-stats.herokuapp.com/?user=dionnenoellabarretto&theme=nightowl)](https://git.io/streak-stats)     |
 | --- | --- | 
 
 <a href="https://github.com/dionnenoellabarretto/github-readme-activity-graph">


### PR DESCRIPTION
## Hello 👋

Hi! I opened this PR because your profile is currently using the official deployment of `github-readme-stats` (`github-readme-stats.vercel.app`).

## Background 📖

The official endpoint (`github-readme-stats.vercel.app`) has been experiencing intermittent outages since late 2025, and at the time of writing this PR it is still down (see `https://github.com/anuraghazra/github-readme-stats/issues/4829`).

## Why this PR? 🛠️

I have deployed a compatible alternative at:

`github-readme-stats.shion.dev`

This deployment was built with high availability as a core goal, and is intended to be maintained indefinitely as a free and open resource for the GitHub community. ☁️

This PR simply switches your profile from `github-readme-stats.vercel.app` to `github-readme-stats.shion.dev` so the cards can render more reliably.

### Quick verification ✅

You can immediately verify the endpoint is working with your actual cards after migration:

![live-endpoint-preview-1](https://github-readme-stats.shion.dev/api/top-langs/?username=dionnenoellabarretto&layout=compact&theme=nightowl)

![live-endpoint-preview-2](https://github-readme-stats.shion.dev/api?username=dionnenoellabarretto&show_icons=true&theme=nightowl)

## Note 💙

This is not meant to replace the upstream project. It is intended as a small reliability improvement for profiles that still depend on the official deployment, and also helps distribute the load away from the official instance.

If you would prefer to keep the current endpoint, please feel free to close this PR. Thank you very much! 🙏

> [!NOTE]
> **About deployment at `github-readme-stats.shion.dev`** 🔗
>
> You can find more details about this deployment at [github-readme-stats.shion.dev](https://github.com/Shion1305/github-readme-stats.shion.dev).
>
> This service runs on my personal infrastructure and I cover the hosting costs as a volunteer effort. If you find it useful and would like to help sustain it, sponsorship through GitHub Sponsors would be very much appreciated ☕
>
> Even just a follow on GitHub means a lot! 😊
>
> [![Follow @Shion1305](https://img.shields.io/github/followers/Shion1305?label=Follow%20%40Shion1305&style=social)](https://github.com/Shion1305) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-Shion1305-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/Shion1305)

<details>
<summary>日本語 🇯🇵</summary>

## こんにちは 👋

突然の Pull Request 失礼します。あなたのプロフィールが `github-readme-stats` の公式エンドポイント（`github-readme-stats.vercel.app`）を利用されていたため、このPRを作成させていただきました。

## 背景 📖

公式エンドポイント（`github-readme-stats.vercel.app`）は 2025 年後半から断続的に障害が発生しており、このPR作成時点でもダウンしたままの状態です（`https://github.com/anuraghazra/github-readme-stats/issues/4829` 参照）。

## このPRについて 🛠️

互換性のある代替エンドポイントを以下にデプロイしました。

`github-readme-stats.shion.dev`

高可用性を重視して構築しており、GitHub コミュニティのための無料かつオープンなリソースとして無期限で運用を続けていく予定です。☁️

このPRでは、プロフィールのエンドポイントを `github-readme-stats.vercel.app` から `github-readme-stats.shion.dev` に切り替えるだけの変更を行っています。

## 補足 💙

本家プロジェクトを置き換える意図はありません。公式デプロイに依存しているプロフィールの信頼性を改善するとともに、公式インスタンスへの負荷を分散することも目的としています。

現在のエンドポイントをそのまま使いたい場合は、遠慮なくこのPRを閉じてください。よろしくお願いいたします！ 🙏

> [!NOTE]
> **`github-readme-stats.shion.dev` について** 🔗
>
> このデプロイの詳細については [github-readme-stats.shion.dev](https://github.com/Shion1305/github-readme-stats.shion.dev) をご覧ください。
>
> このサービスは個人のインフラ上でボランティアとして運用しており、ホスティング費用も自費で賄っています。もしお役に立てていましたら、GitHub Sponsors でのご支援をいただけるととても助かります ☕
>
> フォローだけでもとても励みになります！ 😊
>
> [![Follow @Shion1305](https://img.shields.io/github/followers/Shion1305?label=Follow%20%40Shion1305&style=social)](https://github.com/Shion1305) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-Shion1305-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/Shion1305)

</details>

<details>
<summary>中文 🇨🇳</summary>

## 你好 👋

你好！冒昧提交这个 PR，是因为你的 GitHub Profile 目前使用的是 `github-readme-stats` 的官方部署（`github-readme-stats.vercel.app`）。

## 背景 📖

官方端点（`github-readme-stats.vercel.app`）从 2025 年下半年开始就断断续续出现故障，在提交此 PR 时仍处于不可用状态（参见 `https://github.com/anuraghazra/github-readme-stats/issues/4829`）。

## 这个 PR 的目的 🛠️

我部署了一个兼容的替代端点：

`github-readme-stats.shion.dev`

这个部署以高可用为核心目标，计划作为 GitHub 社区的免费开放资源无限期地运营下去。☁️

这个 PR 只是将你 Profile 中的端点从 `github-readme-stats.vercel.app` 切换到 `github-readme-stats.shion.dev`，让卡片能够更稳定地显示。

## 说明 💙

这并不是为了替代上游项目，而是希望为仍然依赖官方部署的 Profile 提供可靠性改进，同时也有助于分散官方实例的负载。

如果你希望继续使用当前的端点，直接关闭这个 PR 就好。感谢！ 🙏

> [!NOTE]
> **关于 `github-readme-stats.shion.dev`** 🔗
>
> 关于此部署的更多详情，请参阅 [github-readme-stats.shion.dev](https://github.com/Shion1305/github-readme-stats.shion.dev)。
>
> 这个服务运行在我的个人基础设施上，托管费用由我个人承担，纯粹作为志愿贡献。如果对你有帮助，通过 GitHub Sponsors 赞助一下的话我会非常感激 ☕
>
> 哪怕只是关注一下也是很大的鼓励！ 😊
>
> [![Follow @Shion1305](https://img.shields.io/github/followers/Shion1305?label=Follow%20%40Shion1305&style=social)](https://github.com/Shion1305) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-Shion1305-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/Shion1305)

</details>

<details>
<summary>Español 🇪🇸</summary>

## Hola 👋

¡Hola! Disculpa la intrusión. Abrí este PR porque tu perfil está usando actualmente el despliegue oficial de `github-readme-stats` (`github-readme-stats.vercel.app`).

## Contexto 📖

El endpoint oficial (`github-readme-stats.vercel.app`) ha presentado caídas intermitentes desde finales de 2025, y al momento de crear este PR sigue sin funcionar (ver `https://github.com/anuraghazra/github-readme-stats/issues/4829`).

## ¿Por qué este PR? 🛠️

He desplegado una alternativa compatible en:

`github-readme-stats.shion.dev`

Este despliegue fue construido con la alta disponibilidad como objetivo principal, y está pensado para mantenerse de forma indefinida como un recurso gratuito y abierto para la comunidad de GitHub. ☁️

Este PR simplemente cambia tu perfil de `github-readme-stats.vercel.app` a `github-readme-stats.shion.dev`, para que las tarjetas se muestren de forma más fiable.

## Nota 💙

Esto no pretende reemplazar el proyecto original. Su objetivo es ofrecer una mejora de fiabilidad para los perfiles que todavía dependen del despliegue oficial, y también ayudar a distribuir la carga de la instancia oficial.

Si prefieres mantener el endpoint actual, no dudes en cerrar este PR. ¡Muchas gracias! 🙏

> [!NOTE]
> **About deployment at `github-readme-stats.shion.dev`** 🔗
>
> Puedes encontrar más detalles sobre este despliegue en [github-readme-stats.shion.dev](https://github.com/Shion1305/github-readme-stats.shion.dev).
>
> Este servicio funciona en mi infraestructura personal y cubro los costes de alojamiento de forma voluntaria. Si te resulta útil y quieres ayudar a mantenerlo, un patrocinio a través de GitHub Sponsors sería de gran ayuda ☕
>
> ¡Incluso un simple follow en GitHub significa mucho! 😊
>
> [![Follow @Shion1305](https://img.shields.io/github/followers/Shion1305?label=Follow%20%40Shion1305&style=social)](https://github.com/Shion1305) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-Shion1305-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/Shion1305)

</details>

<details>
<summary>Português 🇵🇹</summary>

## Olá 👋

Olá! Desculpe o contato inesperado. Abri este PR porque o seu perfil está usando atualmente a implantação oficial do `github-readme-stats` (`github-readme-stats.vercel.app`).

## Contexto 📖

O endpoint oficial (`github-readme-stats.vercel.app`) vem apresentando quedas intermitentes desde o final de 2025 e, no momento da criação deste PR, continua fora do ar (ver `https://github.com/anuraghazra/github-readme-stats/issues/4829`).

## Por que este PR? 🛠️

Eu implantei uma alternativa compatível em:

`github-readme-stats.shion.dev`

Esta implantação foi construída com alta disponibilidade como objetivo principal e será mantida por tempo indeterminado como um recurso gratuito e aberto para a comunidade do GitHub. ☁️

Este PR apenas troca o endpoint do seu perfil de `github-readme-stats.vercel.app` para `github-readme-stats.shion.dev`, para que os cartões sejam exibidos com mais estabilidade.

## Observação 💙

Isto não tem a intenção de substituir o projeto original. O objetivo é oferecer uma melhoria de confiabilidade para perfis que ainda dependem da implantação oficial, além de ajudar a distribuir a carga da instância oficial.

Se você preferir manter o endpoint atual, fique à vontade para fechar este PR. Muito obrigado! 🙏

> [!NOTE]
> **About deployment at `github-readme-stats.shion.dev`** 🔗
>
> Você pode encontrar mais detalhes sobre esta implantação em [github-readme-stats.shion.dev](https://github.com/Shion1305/github-readme-stats.shion.dev).
>
> Este serviço roda na minha infraestrutura pessoal e eu arco com os custos de hospedagem como um esforço voluntário. Se for útil para você e quiser ajudar a mantê-lo, um patrocínio via GitHub Sponsors seria muito bem-vindo ☕
>
> Mesmo apenas um follow no GitHub já significa muito! 😊
>
> [![Follow @Shion1305](https://img.shields.io/github/followers/Shion1305?label=Follow%20%40Shion1305&style=social)](https://github.com/Shion1305) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-Shion1305-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/Shion1305)

</details>

<details>
<summary>Français 🇫🇷</summary>

## Bonjour 👋

Bonjour ! Veuillez excuser ce PR inattendu. Je l'ai ouvert parce que votre profil utilise actuellement le déploiement officiel de `github-readme-stats` (`github-readme-stats.vercel.app`).

## Contexte 📖

Le point d'accès officiel (`github-readme-stats.vercel.app`) connaît des pannes intermittentes depuis fin 2025, et au moment de la création de cette PR il est toujours hors service (voir `https://github.com/anuraghazra/github-readme-stats/issues/4829`).

## Pourquoi cette PR ? 🛠️

J'ai déployé une alternative compatible à l'adresse suivante :

`github-readme-stats.shion.dev`

Ce déploiement a été conçu avec la haute disponibilité comme objectif principal et est destiné à être maintenu indéfiniment en tant que ressource gratuite et ouverte pour la communauté GitHub. ☁️

Cette PR remplace simplement, dans votre profil, `github-readme-stats.vercel.app` par `github-readme-stats.shion.dev`, afin que les cartes s'affichent de manière plus fiable.

## Remarque 💙

Cette proposition ne vise pas à remplacer le projet d'origine. Elle a pour but d'améliorer la fiabilité pour les profils qui dépendent encore du déploiement officiel, tout en contribuant à répartir la charge de l'instance officielle.

Si vous préférez conserver le point d'accès actuel, n'hésitez pas à fermer cette PR. Merci beaucoup ! 🙏

> [!NOTE]
> **About deployment at `github-readme-stats.shion.dev`** 🔗
>
> Vous pouvez trouver plus de détails sur ce déploiement sur [github-readme-stats.shion.dev](https://github.com/Shion1305/github-readme-stats.shion.dev).
>
> Ce service fonctionne sur mon infrastructure personnelle et j'assume les coûts d'hébergement de manière bénévole. Si vous le trouvez utile et souhaitez aider à le pérenniser, un parrainage via GitHub Sponsors serait très apprécié ☕
>
> Même un simple follow sur GitHub me fait très plaisir ! 😊
>
> [![Follow @Shion1305](https://img.shields.io/github/followers/Shion1305?label=Follow%20%40Shion1305&style=social)](https://github.com/Shion1305) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-Shion1305-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/Shion1305)

</details>

<details>
<summary>Deutsch 🇩🇪</summary>

## Hallo 👋

Hallo! Entschuldige den unerwarteten PR. Ich habe ihn erstellt, weil dein Profil derzeit das offizielle Deployment von `github-readme-stats` (`github-readme-stats.vercel.app`) verwendet.

## Hintergrund 📖

Der offizielle Endpunkt (`github-readme-stats.vercel.app`) hat seit Ende 2025 immer wieder Ausfälle und ist zum Zeitpunkt der Erstellung dieses PRs weiterhin nicht erreichbar (siehe `https://github.com/anuraghazra/github-readme-stats/issues/4829`).

## Warum dieser PR? 🛠️

Ich habe eine kompatible Alternative unter folgender Adresse bereitgestellt:

`github-readme-stats.shion.dev`

Dieses Deployment wurde mit Hochverfügbarkeit als zentralem Ziel aufgebaut und soll auf unbestimmte Zeit als kostenlose und offene Ressource für die GitHub-Community betrieben werden. ☁️

Dieser PR stellt dein Profil lediglich von `github-readme-stats.vercel.app` auf `github-readme-stats.shion.dev` um, damit die Karten zuverlässiger angezeigt werden.

## Hinweis 💙

Dies ist nicht als Ersatz für das ursprüngliche Projekt gedacht. Ziel ist es, die Zuverlässigkeit für Profile zu verbessern, die weiterhin vom offiziellen Deployment abhängen, und gleichzeitig die Last der offiziellen Instanz zu verteilen.

Falls du den aktuellen Endpunkt beibehalten möchtest, kannst du diesen PR gerne schließen. Vielen Dank! 🙏

> [!NOTE]
> **About deployment at `github-readme-stats.shion.dev`** 🔗
>
> Weitere Details zu diesem Deployment findest du unter [github-readme-stats.shion.dev](https://github.com/Shion1305/github-readme-stats.shion.dev).
>
> Dieser Service läuft auf meiner persönlichen Infrastruktur und ich trage die Hosting-Kosten ehrenamtlich. Wenn er dir weiterhilft und du ihn unterstützen möchtest, würde ich mich über ein Sponsoring über GitHub Sponsors sehr freuen ☕
>
> Auch ein einfacher Follow auf GitHub bedeutet mir viel! 😊
>
> [![Follow @Shion1305](https://img.shields.io/github/followers/Shion1305?label=Follow%20%40Shion1305&style=social)](https://github.com/Shion1305) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-Shion1305-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/Shion1305)

</details>

<details>
<summary>한국어 🇰🇷</summary>

## 안녕하세요 👋

안녕하세요! 갑작스러운 PR 죄송합니다. 현재 프로필에서 `github-readme-stats`의 공식 배포(`github-readme-stats.vercel.app`)를 사용하고 계셔서 이 PR을 열게 되었습니다.

## 배경 📖

공식 엔드포인트(`github-readme-stats.vercel.app`)는 2025년 후반부터 간헐적인 장애가 발생하고 있으며, 이 PR 작성 시점에도 접속이 불가능한 상태입니다 (`https://github.com/anuraghazra/github-readme-stats/issues/4829` 참조).

## 왜 이 PR인가요? 🛠️

호환 가능한 대체 엔드포인트를 다음 주소에 배포했습니다.

`github-readme-stats.shion.dev`

이 배포는 고가용성을 핵심 목표로 구축했으며, GitHub 커뮤니티를 위한 무료 오픈 리소스로서 무기한 운영해 나갈 예정입니다. ☁️

이 PR은 프로필의 엔드포인트를 `github-readme-stats.vercel.app`에서 `github-readme-stats.shion.dev`로 변경하여 카드가 더 안정적으로 표시되도록 하는 것입니다.

## 참고 💙

원본 프로젝트를 대체하려는 목적이 아닙니다. 공식 배포에 의존하고 있는 프로필의 신뢰성을 개선하는 동시에, 공식 인스턴스의 부하를 분산하는 데에도 기여하고자 합니다.

현재 엔드포인트를 그대로 유지하고 싶으시다면 이 PR을 닫아 주시면 됩니다. 감사합니다! 🙏

> [!NOTE]
> **About deployment at `github-readme-stats.shion.dev`** 🔗
>
> 이 배포에 대한 자세한 내용은 [github-readme-stats.shion.dev](https://github.com/Shion1305/github-readme-stats.shion.dev)에서 확인하실 수 있습니다.
>
> 이 서비스는 개인 인프라에서 자비로 호스팅 비용을 부담하며 자원봉사로 운영하고 있습니다. 유용하게 사용하고 계시다면 GitHub Sponsors를 통한 후원을 해주시면 정말 큰 도움이 됩니다 ☕
>
> 팔로우만 해주셔도 큰 힘이 됩니다! 😊
>
> [![Follow @Shion1305](https://img.shields.io/github/followers/Shion1305?label=Follow%20%40Shion1305&style=social)](https://github.com/Shion1305) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-Shion1305-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/Shion1305)

</details>

<details>
<summary>Русский 🇷🇺</summary>

## Здравствуйте 👋

Здравствуйте! Прошу прощения за неожиданный PR. Я открыл его, потому что ваш профиль сейчас использует официальное развёртывание `github-readme-stats` (`github-readme-stats.vercel.app`).

## Контекст 📖

Официальная точка доступа (`github-readme-stats.vercel.app`) периодически выходит из строя с конца 2025 года и на момент создания этого PR по-прежнему недоступна (см. `https://github.com/anuraghazra/github-readme-stats/issues/4829`).

## Зачем этот PR? 🛠️

Я развернул совместимую альтернативу по адресу:

`github-readme-stats.shion.dev`

Это развёртывание создано с упором на высокую доступность и будет поддерживаться бессрочно как бесплатный и открытый ресурс для сообщества GitHub. ☁️

Этот PR просто переключает ваш профиль с `github-readme-stats.vercel.app` на `github-readme-stats.shion.dev`, чтобы карточки отображались стабильнее.

## Примечание 💙

Это не попытка заменить исходный проект. Цель — улучшить надёжность для профилей, которые всё ещё зависят от официального развёртывания, а также помочь распределить нагрузку с официального экземпляра.

Если вы предпочитаете оставить текущую точку доступа, просто закройте этот PR. Большое спасибо! 🙏

> [!NOTE]
> **About deployment at `github-readme-stats.shion.dev`** 🔗
>
> Подробности об этом развёртывании можно найти на [github-readme-stats.shion.dev](https://github.com/Shion1305/github-readme-stats.shion.dev).
>
> Этот сервис работает на моей личной инфраструктуре, и я покрываю расходы на хостинг на добровольной основе. Если он оказался вам полезен и вы хотите помочь его поддерживать, спонсорство через GitHub Sponsors будет очень кстати ☕
>
> Даже простая подписка на GitHub — уже большая поддержка! 😊
>
> [![Follow @Shion1305](https://img.shields.io/github/followers/Shion1305?label=Follow%20%40Shion1305&style=social)](https://github.com/Shion1305) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-Shion1305-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/Shion1305)

</details>

<details>
<summary>العربية 🇸🇦</summary>

## مرحبًا 👋

مرحبًا! أعتذر عن هذا الـ PR المفاجئ. فتحته لأن ملفك الشخصي يستخدم حاليًا النشر الرسمي لـ `github-readme-stats` (`github-readme-stats.vercel.app`).

## الخلفية 📖

نقطة الوصول الرسمية (`github-readme-stats.vercel.app`) تعاني من انقطاعات متقطعة منذ أواخر 2025، ولا تزال معطّلة حتى وقت إنشاء هذا الـ PR (راجع `https://github.com/anuraghazra/github-readme-stats/issues/4829`).

## لماذا هذا الـ PR؟ 🛠️

قمت بنشر بديل متوافق على العنوان التالي:

`github-readme-stats.shion.dev`

تم بناء هذا النشر مع التركيز على التوافر العالي كهدف أساسي، وسيتم صيانته إلى أجل غير مسمى كمورد مجاني ومفتوح لمجتمع GitHub. ☁️

هذا الـ PR يقوم فقط بتغيير نقطة الوصول في ملفك الشخصي من `github-readme-stats.vercel.app` إلى `github-readme-stats.shion.dev` حتى تظهر البطاقات بشكل أكثر استقرارًا.

## ملاحظة 💙

هذا ليس بهدف استبدال المشروع الأصلي. الهدف هو تحسين الاعتمادية للملفات الشخصية التي ما زالت تعتمد على النشر الرسمي، وكذلك المساهمة في توزيع الحمل عن النسخة الرسمية.

إذا كنت تفضل الإبقاء على نقطة الوصول الحالية، فلا تتردد في إغلاق هذا الـ PR. شكرًا جزيلاً! 🙏

> [!NOTE]
> **About deployment at `github-readme-stats.shion.dev`** 🔗
>
> يمكنك الاطلاع على مزيد من التفاصيل حول هذا النشر على [github-readme-stats.shion.dev](https://github.com/Shion1305/github-readme-stats.shion.dev).
>
> هذه الخدمة تعمل على بنيتي التحتية الشخصية وأتحمّل تكاليف الاستضافة كجهد تطوعي. إذا وجدت هذا مفيدًا وأردت المساعدة في استمراره، فإن الرعاية عبر GitHub Sponsors ستكون موضع تقدير كبير ☕
>
> حتى مجرد متابعة على GitHub تعني لي الكثير! 😊
>
> [![Follow @Shion1305](https://img.shields.io/github/followers/Shion1305?label=Follow%20%40Shion1305&style=social)](https://github.com/Shion1305) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-Shion1305-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/Shion1305)

</details>

<details>
<summary>हिन्दी 🇮🇳</summary>

## नमस्ते 👋

नमस्ते! अचानक PR के लिए क्षमा करें। मैंने यह PR इसलिए खोला है क्योंकि आपकी प्रोफ़ाइल अभी `github-readme-stats` के आधिकारिक डिप्लॉयमेंट (`github-readme-stats.vercel.app`) का उपयोग कर रही है।

## पृष्ठभूमि 📖

आधिकारिक एंडपॉइंट (`github-readme-stats.vercel.app`) 2025 के अंत से रुक-रुक कर बंद हो रहा है, और इस PR को बनाते समय भी डाउन है (देखें `https://github.com/anuraghazra/github-readme-stats/issues/4829`)।

## यह PR क्यों? 🛠️

मैंने एक संगत विकल्प इस पते पर डिप्लॉय किया है:

`github-readme-stats.shion.dev`

इस डिप्लॉयमेंट को उच्च उपलब्धता को प्राथमिक लक्ष्य मानकर बनाया गया है, और इसे GitHub समुदाय के लिए एक मुफ़्त और खुले संसाधन के रूप में अनिश्चितकाल तक बनाए रखने की योजना है। ☁️

यह PR केवल आपकी प्रोफ़ाइल के एंडपॉइंट को `github-readme-stats.vercel.app` से `github-readme-stats.shion.dev` में बदलता है, ताकि कार्ड अधिक भरोसेमंद तरीके से दिखाई दें।

## नोट 💙

यह मूल प्रोजेक्ट को बदलने के लिए नहीं है। इसका उद्देश्य उन प्रोफ़ाइलों की विश्वसनीयता में सुधार करना है जो अभी भी आधिकारिक डिप्लॉयमेंट पर निर्भर हैं, साथ ही आधिकारिक इंस्टेंस पर लोड कम करने में भी मदद करना है।

यदि आप वर्तमान एंडपॉइंट ही रखना चाहते हैं, तो कृपया इस PR को बेझिझक बंद कर दें। बहुत धन्यवाद! 🙏

> [!NOTE]
> **About deployment at `github-readme-stats.shion.dev`** 🔗
>
> इस डिप्लॉयमेंट की अधिक जानकारी [github-readme-stats.shion.dev](https://github.com/Shion1305/github-readme-stats.shion.dev) पर उपलब्ध है।
>
> यह सेवा मेरे व्यक्तिगत इन्फ्रास्ट्रक्चर पर चल रही है और होस्टिंग का खर्च मैं स्वयं वहन करता हूँ, पूरी तरह स्वैच्छिक रूप से। अगर यह आपके काम आया और आप इसे बनाए रखने में मदद करना चाहते हैं, तो GitHub Sponsors के ज़रिए सहयोग बहुत सराहनीय होगा ☕
>
> सिर्फ़ फ़ॉलो करना भी बहुत मायने रखता है! 😊
>
> [![Follow @Shion1305](https://img.shields.io/github/followers/Shion1305?label=Follow%20%40Shion1305&style=social)](https://github.com/Shion1305) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-Shion1305-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/Shion1305)

</details>

<details>
<summary>Bahasa Indonesia 🇮🇩</summary>

## Halo 👋

Halo! Mohon maaf atas PR yang tiba-tiba ini. Saya membukanya karena profil Anda saat ini menggunakan deployment resmi dari `github-readme-stats` (`github-readme-stats.vercel.app`).

## Latar Belakang 📖

Endpoint resmi (`github-readme-stats.vercel.app`) mengalami gangguan secara berkala sejak akhir 2025, dan pada saat PR ini dibuat masih dalam keadaan down (lihat `https://github.com/anuraghazra/github-readme-stats/issues/4829`).

## Mengapa PR ini? 🛠️

Saya telah men-deploy alternatif yang kompatibel di:

`github-readme-stats.shion.dev`

Deployment ini dibangun dengan ketersediaan tinggi sebagai tujuan utama, dan akan dikelola tanpa batas waktu sebagai sumber daya gratis dan terbuka untuk komunitas GitHub. ☁️

PR ini hanya mengganti endpoint di profil Anda dari `github-readme-stats.vercel.app` ke `github-readme-stats.shion.dev`, agar kartu dapat ditampilkan dengan lebih andal.

## Catatan 💙

Ini tidak dimaksudkan untuk menggantikan proyek aslinya. Tujuannya adalah memberikan peningkatan keandalan bagi profil yang masih bergantung pada deployment resmi, sekaligus membantu mendistribusikan beban dari instansi resmi.

Jika Anda lebih memilih untuk tetap menggunakan endpoint saat ini, silakan tutup PR ini. Terima kasih banyak! 🙏

> [!NOTE]
> **About deployment at `github-readme-stats.shion.dev`** 🔗
>
> Detail lebih lanjut tentang deployment ini dapat ditemukan di [github-readme-stats.shion.dev](https://github.com/Shion1305/github-readme-stats.shion.dev).
>
> Layanan ini berjalan di infrastruktur pribadi saya dan biaya hosting saya tanggung sendiri secara sukarela. Jika ini bermanfaat bagi Anda dan ingin membantu keberlangsungannya, sponsor melalui GitHub Sponsors akan sangat berarti ☕
>
> Bahkan sekadar follow di GitHub pun sudah sangat membantu! 😊
>
> [![Follow @Shion1305](https://img.shields.io/github/followers/Shion1305?label=Follow%20%40Shion1305&style=social)](https://github.com/Shion1305) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-Shion1305-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/Shion1305)

</details>
